### PR TITLE
适配基于OneApi的中转Claude

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,14 +12,16 @@ DEEPSEEK_MODEL=deepseek-reasoner #如果是siliconflow，则使用 deepseek-ai/D
 
 
 # Claude API KEY，默认为 Claude 官方 API，只推荐 Claude 3.5 Sonnet 模型，不推荐其他模型
-CLAUDE_API_KEY=your_claude_api_key   #or your_openrouter_api_key
+CLAUDE_API_KEY=your_claude_api_key
 CLAUDE_MODEL=claude-3-5-sonnet-20241022
 
-# 是否使用 OpenRouter 的 Claude 服务
-#如果使用 OpenRouter，则设置为 true，否则设置为 false
-USE_OPENROUTER=false
+# Claude Provider
+# 若使用官方则填anthropic, 使用OpenRouter则填openrouter
+# 若使用中转平台(国内大多数中转服务均为OneApi/基于前者的NewApi)则填oneapi
+CLAUDE_PROVIDER=anthropic
 
 # 如果使用 OpenRouter，这里填写 OpenRouter 的 API URL https://openrouter.ai/api/v1/chat/completions, 
+# 如果使用中转平台则填写相应的 API URL: 例如 https://api.oneapi.com/v1/chat/completions
 # 默认为 Anthropic 的 API URL https://api.anthropic.com/v1/messages
 CLAUDE_API_URL=https://api.anthropic.com/v1/messages
 

--- a/app/clients/claude_client.py
+++ b/app/clients/claude_client.py
@@ -6,7 +6,7 @@ from .base_client import BaseClient
 
 
 class ClaudeClient(BaseClient):
-    def __init__(self, api_key: str, api_url: str = "https://api.anthropic.com/v1/messages", is_openrouter: bool = False):
+    def __init__(self, api_key: str, api_url: str = "https://api.anthropic.com/v1/messages", provider: str = "anthropic"):
         """初始化 Claude 客户端
         
         Args:
@@ -15,7 +15,7 @@ class ClaudeClient(BaseClient):
             is_openrouter: 是否使用 OpenRouter API
         """
         super().__init__(api_key, api_url)
-        self.is_openrouter = is_openrouter
+        self.provider = provider
         
     async def stream_chat(self, messages: list, model: str = "claude-3-5-sonnet-20241022") -> AsyncGenerator[tuple[str, str], None]:
         """流式对话
@@ -29,7 +29,8 @@ class ClaudeClient(BaseClient):
                 内容类型: "answer"
                 内容: 实际的文本内容
         """
-        if self.is_openrouter:
+
+        if self.provider == "openrouter":
             logger.info("使用 OpenRouter API 作为 Claude 3.5 Sonnet 供应商 ")
             # 转换模型名称为 OpenRouter 格式
             model = "anthropic/claude-3.5-sonnet"
@@ -46,7 +47,19 @@ class ClaudeClient(BaseClient):
                 "messages": messages,
                 "stream": True
             }
-        else:
+        elif self.provider == "oneapi":
+            logger.info("使用 OneAPI API 作为 Claude 3.5 Sonnet 供应商 ")
+            headers = {
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json"
+            }
+
+            data = {
+                "model": model,
+                "messages": messages,
+                "stream": True
+            }
+        elif self.provider == "anthropic":
             logger.info("使用 Anthropic API 作为 Claude 3.5 Sonnet 供应商 ")
             headers = {
                 "x-api-key": self.api_key,
@@ -61,6 +74,8 @@ class ClaudeClient(BaseClient):
                 "max_tokens": 8192,
                 "stream": True
             }
+        else:
+            raise ValueError(f"不支持的Claude Provider: {self.provider}")
         
         async for chunk in self._make_request(headers, data):
             chunk_str = chunk.decode('utf-8')
@@ -75,16 +90,18 @@ class ClaudeClient(BaseClient):
                         
                     try:
                         data = json.loads(json_str)
-                        if self.is_openrouter:
-                            # OpenRouter 格式
+                        if self.provider in ("openrouter", "oneapi"):
+                            # OpenRouter/OneApi 格式
                             content = data.get('choices', [{}])[0].get('delta', {}).get('content', '')
                             if content:
                                 yield "answer", content
-                        else:
+                        elif self.provider == "anthropic":
                             # Anthropic 格式
                             if data.get('type') == 'content_block_delta':
                                 content = data.get('delta', {}).get('text', '')
                                 if content:
                                     yield "answer", content
+                        else:
+                            raise ValueError(f"不支持的Claude Provider: {self.provider}")
                     except json.JSONDecodeError:
                         continue

--- a/app/deepclaude/deepclaude.py
+++ b/app/deepclaude/deepclaude.py
@@ -13,7 +13,7 @@ class DeepClaude:
     def __init__(self, deepseek_api_key: str, claude_api_key: str, 
                  deepseek_api_url: str = "https://api.deepseek.com/v1/chat/completions", 
                  claude_api_url: str = "https://api.anthropic.com/v1/messages",
-                 is_openrouter: bool = False):
+                 claude_provider: str = "anthropic"):
         """初始化 API 客户端
         
         Args:
@@ -21,7 +21,7 @@ class DeepClaude:
             claude_api_key: Claude API密钥
         """
         self.deepseek_client = DeepSeekClient(deepseek_api_key, deepseek_api_url)
-        self.claude_client = ClaudeClient(claude_api_key, claude_api_url, is_openrouter)
+        self.claude_client = ClaudeClient(claude_api_key, claude_api_url, claude_provider)
     
     async def chat_completions_with_stream(self, messages: list, 
                                          deepseek_model: str = "deepseek-reasoner",

--- a/app/main.py
+++ b/app/main.py
@@ -16,7 +16,8 @@ app = FastAPI(title="DeepClaude API")
 # 从环境变量获取 API 密钥、地址以及模型名称
 CLAUDE_API_KEY = os.getenv("CLAUDE_API_KEY")
 CLAUDE_MODEL = os.getenv("CLAUDE_MODEL")
-USE_OPENROUTER = os.getenv("USE_OPENROUTER", "false").lower() == "true"
+# USE_OPENROUTER = os.getenv("USE_OPENROUTER", "false").lower() == "true"
+CLAUDE_PROVIDER = os.getenv("CLAUDE_PROVIDER", "anthropic") # Claude模型提供商, 默认为anthropic
 CLAUDE_API_URL = os.getenv("CLAUDE_API_URL", "https://api.anthropic.com/v1/messages")
 
 DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY")
@@ -61,7 +62,7 @@ async def chat_completions(request: Request):
             CLAUDE_API_KEY, 
             DEEPSEEK_API_URL,
             CLAUDE_API_URL,
-            USE_OPENROUTER
+            CLAUDE_PROVIDER
         )
         
         # 4. 返回流式响应


### PR DESCRIPTION
### 1. `CLAUDE_PROVIDER`
在`env`中添加环境变量`CLAUDE_PROVIDER`, 取代`USE_OPENROUTER`. 考虑到后续发展过程中Provider的类型/数量会逐渐增加, 所以改为这种方式来管理.

### 2. `claude_client.py`
配合`CLAUDE_PROVIDER`, 使用`if-elif-else`选择不同的适配分支, 实现兼容.

🎉感谢作者的无私奉献~