### PR TITLE
新增跨域配置

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 # 客户端请求时允许通过请求的 API KEY，无需在当前环境变量当中手动添加 Bearer，目前只支持一个，未来可以升级为数组/toml/yaml 或专门的管理工具
 ALLOW_API_KEY=your_api_key 
 
+# 服务端跨域配置
+# 允许访问的域名，多个域名使用逗号分隔(中间不能有空格)，例如：http://localhost:3000,https://chat.example.com
+# 如果允许所有域名访问，则填写 *
+ALLOW_ORIGINS=your_allow_origins
+
 # DeepSeek API KEY，默认为 DeepSeek 官方 API，只支持 r1 系列模型（包括基于 llama 和 qwen 的密集模型，1.5b、7b、8b、14b、32b、70b、671b）
 # 除了采用官网的 DeepSeek r1 外，还推荐以下：
 # 1.SiliconFlow 的 deepseek-ai/DeepSeek-R1 获取 API KEY 的链接：https://cloud.siliconflow.cn/i/RXikvHE2 (点击此链接可以获得到 2000 万免费 tokens)
@@ -24,7 +29,6 @@ CLAUDE_PROVIDER=anthropic
 # 如果使用中转平台则填写相应的 API URL: 例如 https://api.oneapi.com/v1/chat/completions
 # 默认为 Anthropic 的 API URL https://api.anthropic.com/v1/messages
 CLAUDE_API_URL=https://api.anthropic.com/v1/messages
-
 
 # 日志配置
 # 可选值：DEBUG, INFO, WARNING, ERROR, CRITICAL

--- a/.env.example
+++ b/.env.example
@@ -12,14 +12,16 @@ DEEPSEEK_MODEL=deepseek-reasoner #如果是siliconflow，则使用 deepseek-ai/D
 
 
 # Claude API KEY，默认为 Claude 官方 API，只推荐 Claude 3.5 Sonnet 模型，不推荐其他模型
-CLAUDE_API_KEY=your_claude_api_key   #or your_openrouter_api_key
+CLAUDE_API_KEY=your_claude_api_key
 CLAUDE_MODEL=claude-3-5-sonnet-20241022
 
-# 是否使用 OpenRouter 的 Claude 服务
-#如果使用 OpenRouter，则设置为 true，否则设置为 false
-USE_OPENROUTER=false
+# Claude Provider
+# 若使用官方则填anthropic, 使用OpenRouter则填openrouter
+# 若使用中转平台(国内大多数中转服务均为OneApi/基于前者的NewApi)则填oneapi
+CLAUDE_PROVIDER=anthropic
 
 # 如果使用 OpenRouter，这里填写 OpenRouter 的 API URL https://openrouter.ai/api/v1/chat/completions, 
+# 如果使用中转平台则填写相应的 API URL: 例如 https://api.oneapi.com/v1/chat/completions
 # 默认为 Anthropic 的 API URL https://api.anthropic.com/v1/messages
 CLAUDE_API_URL=https://api.anthropic.com/v1/messages
 

--- a/app/clients/claude_client.py
+++ b/app/clients/claude_client.py
@@ -6,7 +6,7 @@ from .base_client import BaseClient
 
 
 class ClaudeClient(BaseClient):
-    def __init__(self, api_key: str, api_url: str = "https://api.anthropic.com/v1/messages", is_openrouter: bool = False):
+    def __init__(self, api_key: str, api_url: str = "https://api.anthropic.com/v1/messages", provider: str = "anthropic"):
         """初始化 Claude 客户端
         
         Args:
@@ -15,7 +15,7 @@ class ClaudeClient(BaseClient):
             is_openrouter: 是否使用 OpenRouter API
         """
         super().__init__(api_key, api_url)
-        self.is_openrouter = is_openrouter
+        self.provider = provider
         
     async def stream_chat(self, messages: list, model: str = "claude-3-5-sonnet-20241022") -> AsyncGenerator[tuple[str, str], None]:
         """流式对话
@@ -29,7 +29,8 @@ class ClaudeClient(BaseClient):
                 内容类型: "answer"
                 内容: 实际的文本内容
         """
-        if self.is_openrouter:
+
+        if self.provider == "openrouter":
             logger.info("使用 OpenRouter API 作为 Claude 3.5 Sonnet 供应商 ")
             # 转换模型名称为 OpenRouter 格式
             model = "anthropic/claude-3.5-sonnet"
@@ -46,7 +47,19 @@ class ClaudeClient(BaseClient):
                 "messages": messages,
                 "stream": True
             }
-        else:
+        elif self.provider == "oneapi":
+            logger.info("使用 OneAPI API 作为 Claude 3.5 Sonnet 供应商 ")
+            headers = {
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json"
+            }
+
+            data = {
+                "model": model,
+                "messages": messages,
+                "stream": True
+            }
+        elif self.provider == "anthropic":
             logger.info("使用 Anthropic API 作为 Claude 3.5 Sonnet 供应商 ")
             headers = {
                 "x-api-key": self.api_key,
@@ -61,6 +74,8 @@ class ClaudeClient(BaseClient):
                 "max_tokens": 8192,
                 "stream": True
             }
+        else:
+            raise ValueError(f"不支持的Claude Provider: {self.provider}")
         
         async for chunk in self._make_request(headers, data):
             chunk_str = chunk.decode('utf-8')
@@ -75,16 +90,18 @@ class ClaudeClient(BaseClient):
                         
                     try:
                         data = json.loads(json_str)
-                        if self.is_openrouter:
-                            # OpenRouter 格式
+                        if self.provider in ("openrouter", "oneapi"):
+                            # OpenRouter/OneApi 格式
                             content = data.get('choices', [{}])[0].get('delta', {}).get('content', '')
                             if content:
                                 yield "answer", content
-                        else:
+                        elif self.provider == "anthropic":
                             # Anthropic 格式
                             if data.get('type') == 'content_block_delta':
                                 content = data.get('delta', {}).get('text', '')
                                 if content:
                                     yield "answer", content
+                        else:
+                            raise ValueError(f"不支持的Claude Provider: {self.provider}")
                     except json.JSONDecodeError:
                         continue

--- a/app/deepclaude/deepclaude.py
+++ b/app/deepclaude/deepclaude.py
@@ -13,7 +13,7 @@ class DeepClaude:
     def __init__(self, deepseek_api_key: str, claude_api_key: str, 
                  deepseek_api_url: str = "https://api.deepseek.com/v1/chat/completions", 
                  claude_api_url: str = "https://api.anthropic.com/v1/messages",
-                 is_openrouter: bool = False):
+                 claude_provider: str = "anthropic"):
         """初始化 API 客户端
         
         Args:
@@ -21,7 +21,7 @@ class DeepClaude:
             claude_api_key: Claude API密钥
         """
         self.deepseek_client = DeepSeekClient(deepseek_api_key, deepseek_api_url)
-        self.claude_client = ClaudeClient(claude_api_key, claude_api_url, is_openrouter)
+        self.claude_client = ClaudeClient(claude_api_key, claude_api_url, claude_provider)
     
     async def chat_completions_with_stream(self, messages: list, 
                                          deepseek_model: str = "deepseek-reasoner",

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ load_dotenv()
 
 from fastapi import FastAPI, Depends, Request
 from fastapi.responses import StreamingResponse
+from fastapi.middleware.cors import CORSMiddleware
 from app.utils.logger import logger
 from app.utils.auth import verify_api_key
 from app.deepclaude.deepclaude import DeepClaude
@@ -13,7 +14,9 @@ import os
 
 app = FastAPI(title="DeepClaude API")
 
-# 从环境变量获取 API 密钥、地址以及模型名称
+# 从环境变量获取 CORS配置, API 密钥、地址以及模型名称
+ALLOW_ORIGINS = os.getenv("ALLOW_ORIGINS", "*")
+
 CLAUDE_API_KEY = os.getenv("CLAUDE_API_KEY")
 CLAUDE_MODEL = os.getenv("CLAUDE_MODEL")
 # USE_OPENROUTER = os.getenv("USE_OPENROUTER", "false").lower() == "true"
@@ -23,6 +26,17 @@ CLAUDE_API_URL = os.getenv("CLAUDE_API_URL", "https://api.anthropic.com/v1/messa
 DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY")
 DEEPSEEK_API_URL = os.getenv("DEEPSEEK_API_URL")
 DEEPSEEK_MODEL = os.getenv("DEEPSEEK_MODEL")
+
+# CORS设置
+allow_origins_list = ALLOW_ORIGINS.split(",") if ALLOW_ORIGINS else [] # 将逗号分隔的字符串转换为列表
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=allow_origins_list,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # 验证日志级别
 logger.debug("当前日志级别为 DEBUG")

--- a/app/main.py
+++ b/app/main.py
@@ -16,7 +16,8 @@ app = FastAPI(title="DeepClaude API")
 # 从环境变量获取 API 密钥、地址以及模型名称
 CLAUDE_API_KEY = os.getenv("CLAUDE_API_KEY")
 CLAUDE_MODEL = os.getenv("CLAUDE_MODEL")
-USE_OPENROUTER = os.getenv("USE_OPENROUTER", "false").lower() == "true"
+# USE_OPENROUTER = os.getenv("USE_OPENROUTER", "false").lower() == "true"
+CLAUDE_PROVIDER = os.getenv("CLAUDE_PROVIDER", "anthropic") # Claude模型提供商, 默认为anthropic
 CLAUDE_API_URL = os.getenv("CLAUDE_API_URL", "https://api.anthropic.com/v1/messages")
 
 DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY")
@@ -61,7 +62,7 @@ async def chat_completions(request: Request):
             CLAUDE_API_KEY, 
             DEEPSEEK_API_URL,
             CLAUDE_API_URL,
-            USE_OPENROUTER
+            CLAUDE_PROVIDER
         )
         
         # 4. 返回流式响应


### PR DESCRIPTION
## 主要更改
在配置文件中增加跨域环境变量的设置, 并在app启动后设置跨域信息.

## 更改说明

### 1. `.env.example`
增加`ALLOW_ORIGINS`环境变量, 可以设置多个允许的域名或者使用`*`设置为允许所有域名.

### 2. `main.py`
在`fastapi`中引入`CORSMiddleware`, 在`app`实例化之后, 调用`add_middleware`方法, 传入由`ALLOW_ORIGINS`环境变量字符串切片而来的`List[str]`, 完成对跨域允许域名的设置.