### PR TITLE
新增DEEPSEEK_PROVIDER用于区分不同提供商, 支持设定temperature等参数

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,13 @@ DEEPSEEK_API_KEY=your_deepseek_api_key
 DEEPSEEK_API_URL=https://api.deepseek.com/v1/chat/completions #如果是siliconflow，则使用 https://api.siliconflow.cn/v1/chat/completions
 DEEPSEEK_MODEL=deepseek-reasoner #如果是siliconflow，则使用 deepseek-ai/DeepSeek-R1
 
+# DeepSeek Provider
+# 若使用官方则填 deepseek
+# 若使用硅基流动(SiliconFlow)则填 siliconflow
+# 若使用其他则填 other
+# 该变量用于区别返回体中推理过程的格式
+# (deepseek与siliconflow采用增加reasoning_content承载推理过程内容, 其他Privider还有采用<think></think>标签)
+DEEPSEEK_PROVIDER=deepseek
 
 # Claude API KEY，默认为 Claude 官方 API，只推荐 Claude 3.5 Sonnet 模型，不推荐其他模型
 CLAUDE_API_KEY=your_claude_api_key

--- a/app/clients/deepseek_client.py
+++ b/app/clients/deepseek_client.py
@@ -6,7 +6,7 @@ from .base_client import BaseClient
 
 
 class DeepSeekClient(BaseClient):
-    def __init__(self, api_key: str, api_url: str = "https://api.siliconflow.cn/v1/chat/completions"):
+    def __init__(self, api_key: str, api_url: str = "https://api.siliconflow.cn/v1/chat/completions", provider: str = "deepseek"):
         """初始化 DeepSeek 客户端
         
         Args:
@@ -14,6 +14,7 @@ class DeepSeekClient(BaseClient):
             api_url: DeepSeek API地址
         """
         super().__init__(api_key, api_url)
+        self.provider = provider
         
     def _process_think_tag_content(self, content: str) -> tuple[bool, str]:
         """处理包含 think 标签的内容
@@ -81,7 +82,7 @@ class DeepSeekClient(BaseClient):
                         if data and data.get("choices") and data["choices"][0].get("delta"):
                             delta = data["choices"][0]["delta"]
                             
-                            if model == "deepseek-reasoner" or model == "deepseek-ai/DeepSeek-R1":
+                            if self.provider in ('deepseek', 'siliconflow'):
                                 # 处理 reasoning_content
                                 if delta.get("reasoning_content"):
                                     content = delta["reasoning_content"]

--- a/app/deepclaude/deepclaude.py
+++ b/app/deepclaude/deepclaude.py
@@ -13,6 +13,7 @@ class DeepClaude:
     def __init__(self, deepseek_api_key: str, claude_api_key: str, 
                  deepseek_api_url: str = "https://api.deepseek.com/v1/chat/completions", 
                  claude_api_url: str = "https://api.anthropic.com/v1/messages",
+                 deepseek_provider: str = "deepseek",
                  claude_provider: str = "anthropic"):
         """初始化 API 客户端
         
@@ -20,7 +21,7 @@ class DeepClaude:
             deepseek_api_key: DeepSeek API密钥
             claude_api_key: Claude API密钥
         """
-        self.deepseek_client = DeepSeekClient(deepseek_api_key, deepseek_api_url)
+        self.deepseek_client = DeepSeekClient(deepseek_api_key, deepseek_api_url, deepseek_provider)
         self.claude_client = ClaudeClient(claude_api_key, claude_api_url, claude_provider)
     
     async def chat_completions_with_stream(self, messages: list, 

--- a/app/deepclaude/deepclaude.py
+++ b/app/deepclaude/deepclaude.py
@@ -9,7 +9,7 @@ from app.clients import DeepSeekClient, ClaudeClient
 
 class DeepClaude:
     """处理 DeepSeek 和 Claude API 的流式输出衔接"""
-    
+
     def __init__(self, deepseek_api_key: str, claude_api_key: str, 
                  deepseek_api_url: str = "https://api.deepseek.com/v1/chat/completions", 
                  claude_api_url: str = "https://api.anthropic.com/v1/messages",
@@ -23,10 +23,14 @@ class DeepClaude:
         """
         self.deepseek_client = DeepSeekClient(deepseek_api_key, deepseek_api_url, deepseek_provider)
         self.claude_client = ClaudeClient(claude_api_key, claude_api_url, claude_provider)
-    
-    async def chat_completions_with_stream(self, messages: list, 
-                                         deepseek_model: str = "deepseek-reasoner",
-                                         claude_model: str = "claude-3-5-sonnet-20241022") -> AsyncGenerator[bytes, None]:
+
+    async def chat_completions_with_stream(
+        self,
+        messages: list,
+        model_arg: tuple[float, float, float, float],
+        deepseek_model: str = "deepseek-reasoner",
+        claude_model: str = "claude-3-5-sonnet-20241022"
+    ) -> AsyncGenerator[bytes, None]:
         """处理完整的流式输出过程
         
         Args:
@@ -59,12 +63,12 @@ class DeepClaude:
         output_queue = asyncio.Queue()
         # 队列，用于传递 DeepSeek 推理内容给 Claude
         claude_queue = asyncio.Queue()
-        
+
         # 用于存储 DeepSeek 的推理累积内容
         reasoning_content = []
-        
+
         async def process_deepseek():
-            logger.info(f"开始处理 DeepSeek 流，使用模型：{deepseek_model}")
+            logger.info(f"开始处理 DeepSeek 流，使用模型：{deepseek_model}, 提供商: {self.deepseek_client.provider}")
             try:
                 async for content_type, content in self.deepseek_client.stream_chat(messages, deepseek_model):
                     if content_type == "reasoning":
@@ -95,7 +99,7 @@ class DeepClaude:
             # 用 None 标记 DeepSeek 任务结束
             logger.info("DeepSeek 任务处理完成，标记结束")
             await output_queue.put(None)
-        
+
         async def process_claude():
             try:
                 logger.info("等待获取 DeepSeek 的推理内容...")
@@ -115,7 +119,13 @@ class DeepClaude:
                 # 处理可能 messages 内存在 role = system 的情况，如果有，则去掉当前这一条的消息对象
                 claude_messages = [message for message in claude_messages if message.get("role", "") != "system"]
 
-                async for content_type, content in self.claude_client.stream_chat(claude_messages, claude_model):
+                logger.info(f"开始处理 Claude 流，使用模型: {claude_model}, 提供商: {self.claude_client.provider}")
+
+                async for content_type, content in self.claude_client.stream_chat(
+                    messages=claude_messages,
+                    model_arg=model_arg,
+                    model=claude_model,
+                ):
                     if content_type == "answer":
                         response = {
                             "id": chat_id,
@@ -134,6 +144,7 @@ class DeepClaude:
             except Exception as e:
                 logger.error(f"处理 Claude 流时发生错误: {e}")
             # 用 None 标记 Claude 任务结束
+            logger.info("Claude 任务处理完成，标记结束")
             await output_queue.put(None)
         
         # 创建并发任务

--- a/app/main.py
+++ b/app/main.py
@@ -24,6 +24,7 @@ CLAUDE_API_URL = os.getenv("CLAUDE_API_URL", "https://api.anthropic.com/v1/messa
 
 DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY")
 DEEPSEEK_API_URL = os.getenv("DEEPSEEK_API_URL")
+DEEPSEEK_PROVIDER = os.getenv("DEEPSEEK_PROVIDER", "deepseek") # R1模型提供商, 默认为deepseek
 DEEPSEEK_MODEL = os.getenv("DEEPSEEK_MODEL")
 
 # CORS设置
@@ -75,6 +76,7 @@ async def chat_completions(request: Request):
             CLAUDE_API_KEY, 
             DEEPSEEK_API_URL,
             CLAUDE_API_URL,
+            DEEPSEEK_PROVIDER,
             CLAUDE_PROVIDER
         )
         

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from dotenv import load_dotenv
 
 # 加载环境变量
@@ -10,7 +11,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.utils.logger import logger
 from app.utils.auth import verify_api_key
 from app.deepclaude.deepclaude import DeepClaude
-import os
 
 app = FastAPI(title="DeepClaude API")
 
@@ -38,6 +38,20 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# 创建 DeepClaude 实例, 提出为Global变量
+if not DEEPSEEK_API_KEY or not CLAUDE_API_KEY:
+    logger.critical("请设置环境变量 CLAUDE_API_KEY 和 DEEPSEEK_API_KEY")
+    sys.exit(1)
+
+deep_claude = DeepClaude(
+    DEEPSEEK_API_KEY,
+    CLAUDE_API_KEY,
+    DEEPSEEK_API_URL,
+    CLAUDE_API_URL,
+    DEEPSEEK_PROVIDER,
+    CLAUDE_PROVIDER
+)
+
 # 验证日志级别
 logger.debug("当前日志级别为 DEBUG")
 logger.info("开始请求")
@@ -54,42 +68,52 @@ async def chat_completions(request: Request):
     请求体格式应与 OpenAI API 保持一致，包含：
     - messages: 消息列表
     - model: 模型名称（可选）
-    - stream: 是否使用流式输出（必须为 True）
+    - stream: 是否使用流式输出（必须为 True)
+    - temperature: 随机性 (可选)
+    - top_p: top_p (可选)
+    - presence_penalty: 话题新鲜度（可选）
+    - frequency_penalty: 频率惩罚度（可选）
     """
 
     try:
-        # 1. 获取并验证请求数据
+        # 1. 获取基础信息
         body = await request.json()
         messages = body.get("messages")
-        if not messages:
-            return {"error": "messages 不能为空"}
-        
-        if not body.get("stream", False):
-            return {"error": "目前仅支持流式输出，stream 必须为 True"}
-        
-        # 3. 创建 DeepClaude 实例
-        if not DEEPSEEK_API_KEY or not CLAUDE_API_KEY:
-            return {"error": "未设置 API 密钥"}
-            
-        deep_claude = DeepClaude(
-            DEEPSEEK_API_KEY, 
-            CLAUDE_API_KEY, 
-            DEEPSEEK_API_URL,
-            CLAUDE_API_URL,
-            DEEPSEEK_PROVIDER,
-            CLAUDE_PROVIDER
+
+        # 2. 获取并验证参数
+        model_arg = (
+            get_and_validate_params(body)
         )
-        
-        # 4. 返回流式响应
+
+        # 3. 返回流式响应
         return StreamingResponse(
             deep_claude.chat_completions_with_stream(
                 messages=messages,
+                model_arg=model_arg,
                 deepseek_model=DEEPSEEK_MODEL,
                 claude_model=CLAUDE_MODEL
             ),
             media_type="text/event-stream"
         )
-        
+
     except Exception as e:
         logger.error(f"处理请求时发生错误: {e}")
         return {"error": str(e)}
+
+
+def get_and_validate_params(body):
+    """提取获取和验证请求参数的函数"""
+    # TODO: 默认值设定允许自定义
+    temperature: float = body.get("temperature", 0.5)
+    top_p: float = body.get("top_p", 0.9)
+    presence_penalty: float = body.get("presence_penalty", 0.0)
+    frequency_penalty: float = body.get("frequency_penalty", 0.0)
+
+    if not body.get("stream", False):
+        raise ValueError("目前仅支持流式输出, stream 必须为 True")
+
+    if "sonnet" in body.get("model", ""): # Only Sonnet 设定 temperature 必须在 0 到 1 之间
+        if not isinstance(temperature, (float)) or temperature < 0.0 or temperature > 1.0:
+            raise ValueError("Sonnet 设定 temperature 必须在 0 到 1 之间")
+
+    return (temperature, top_p, presence_penalty, frequency_penalty)


### PR DESCRIPTION
## 主要更改
增加`DEEPSEEK_PROVIDER`环境变量用于区分不同DeepSeek R1的提供商

## 更改说明

### 1. `.env.example`

鉴于DeepSeek的提供商日渐复杂而且众多R1蒸馏模型上架, DeepClaude需要适应不同提供商的格式来针对性提取推理过程. 故增加`DEEPSEEK_PROVIDER`环境变量, 专门用于进行提供商区分.

### 2. `deepseek_client.py`

原先使用`modle`作为区分推理过程格式/数据结构的依据, 这样使得R1的模型名称变得难以扩展(无法使用低价的蒸馏模型来代替R1). 改为使用`provider`来区分, 更符合"数据结构有别"的内在逻辑. 同时也为后续增加适配Provider留下扩展空间.