### PR TITLE
优化serverless平台部署

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,41 @@
+name: Public Upstream Sync
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+jobs:
+  sync_latest_from_upstream:
+    name: Sync latest commits from upstream repo
+    runs-on: ubuntu-latest
+
+    steps:
+      # 标准签出
+      - name: Checkout target repo
+        uses: actions/checkout@v4
+# 如果上游仓库有对.github/workflows/下的文件进行变更，则需要使用有workflow权限的token
+#        with:
+#          token: ${{ secrets.ACTION_TOKEN }}
+   
+      # 获取分支名
+      - name: Get branch name (merge)
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
+      - name: Get branch name (pull request)
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
+
+      # 运行同步动作
+      - name: Sync upstream changes
+        id: sync
+        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
+        with:
+          upstream_sync_repo: ErlichLiu/DeepClaude
+          upstream_sync_branch: ${{ env.BRANCH_NAME }}
+          target_sync_branch: ${{ env.BRANCH_NAME }}
+          target_repo_token: ${{ secrets.GITHUB_TOKEN }}
+          upstream_pull_args: --allow-unrelated-histories --no-edit
+          shallow_since: '1 days ago'
+          test_mode: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install --no-cache-dir \
 
 # 复制项目文件
 COPY ./app ./app
-
+COPY .env.example ./app/.env
 # 暴露端口
 EXPOSE 8000
 


### PR DESCRIPTION
增加actions定时同步主仓库，需要开启actions读写权限。做到github私有仓库和serverless平台联动。serverless平台直接修改.env文件填入密钥+fork仓库为私有后即可部署。