### PR TITLE
增加OpenRouter作为DeepSeek Provider的支持

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ ALLOW_ORIGINS=*
 DEEPSEEK_API_KEY=your_deepseek_api_key
 DEEPSEEK_API_URL=https://api.deepseek.com/v1/chat/completions #如果是siliconflow，则使用 https://api.siliconflow.cn/v1/chat/completions
 DEEPSEEK_MODEL=deepseek-reasoner #如果是siliconflow，则使用 deepseek-ai/DeepSeek-R1
+DEEPSEEK_PROVIDER=deepseek #可选填siliconflow、openrouter
 
 # DeepSeek推理过程格式配置
 # 该变量用于区别返回体中推理过程的格式

--- a/app/clients/deepseek_client.py
+++ b/app/clients/deepseek_client.py
@@ -61,6 +61,8 @@ class DeepSeekClient(BaseClient):
             "messages": messages,
             "stream": True,
         }
+        if self.provider == "openrouter":
+            data["include_reasoning"] = True
         
         logger.debug(f"开始流式对话：{data}")
 
@@ -83,13 +85,14 @@ class DeepSeekClient(BaseClient):
                             delta = data["choices"][0]["delta"]
                             
                             if is_origin_reasoning:
+                                reasoning_field = "reasoning" if self.provider == "openrouter" else "reasoning_content"
                                 # 处理 reasoning_content
-                                if delta.get("reasoning_content"):
-                                    content = delta["reasoning_content"]
+                                if delta.get(reasoning_field):
+                                    content = delta[reasoning_field]
                                     logger.debug(f"提取推理内容：{content}")
                                     yield "reasoning", content
                                 
-                                if delta.get("reasoning_content") is None and delta.get("content"):
+                                if delta.get(reasoning_field) is None and delta.get("content"):
                                     content = delta["content"]
                                     logger.info(f"提取内容信息，推理阶段结束: {content}")
                                     yield "content", content

--- a/app/deepclaude/deepclaude.py
+++ b/app/deepclaude/deepclaude.py
@@ -14,6 +14,7 @@ class DeepClaude:
                  deepseek_api_url: str = "https://api.deepseek.com/v1/chat/completions", 
                  claude_api_url: str = "https://api.anthropic.com/v1/messages",
                  claude_provider: str = "anthropic",
+                 deepseek_provider: str = "deepseek",
                  is_origin_reasoning: bool = True):
         """初始化 API 客户端
         
@@ -21,7 +22,7 @@ class DeepClaude:
             deepseek_api_key: DeepSeek API密钥
             claude_api_key: Claude API密钥
         """
-        self.deepseek_client = DeepSeekClient(deepseek_api_key, deepseek_api_url)
+        self.deepseek_client = DeepSeekClient(deepseek_api_key, deepseek_api_url, deepseek_provider)
         self.claude_client = ClaudeClient(claude_api_key, claude_api_url, claude_provider)
         self.is_origin_reasoning = is_origin_reasoning
 

--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,7 @@ CLAUDE_API_URL = os.getenv("CLAUDE_API_URL", "https://api.anthropic.com/v1/messa
 DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY")
 DEEPSEEK_API_URL = os.getenv("DEEPSEEK_API_URL")
 DEEPSEEK_MODEL = os.getenv("DEEPSEEK_MODEL")
+DEEPSEEK_PROVIDER = os.getenv("DEEPSEEK_PROVIDER", "deepseek")
 
 IS_ORIGIN_REASONING = os.getenv("IS_ORIGIN_REASONING", "True").lower() == "true"
 
@@ -50,6 +51,7 @@ deep_claude = DeepClaude(
     DEEPSEEK_API_URL,
     CLAUDE_API_URL,
     CLAUDE_PROVIDER,
+    DEEPSEEK_PROVIDER,
     IS_ORIGIN_REASONING
 )
 


### PR DESCRIPTION
OpenRouter对于DeepSeek R1相关的模型的字段和官方API用到的字段有细微差别: 

1. Request Body中需要增加 "include_reasoning": true
2. Response中推理字段的名字是"reasoning"并非"reasoning_content"

因此这个PR通过在.env中设置 `DEEPSEEK_PROVIDER=openrouter` 解决上述问题。

另外有一个问题想问作者: 在修改代码时看到在deepseek_client中有is_origin_reasoning的相关判断逻辑, 请问这个origin reasoning是出于什么考量, 在代码中好像没有看到相关描述. 谢谢!
