### PR TITLE
Claude侧支持客户端请求体中的model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,8 +23,11 @@ DEEPSEEK_MODEL=deepseek-reasoner #如果是siliconflow，则使用 deepseek-ai/D
 # 填写true表示使用 Origin_Reasoning 格式，填写false表示使用 <think></think> 标签格式
 IS_ORIGIN_REASONING=true
 
-# Claude API KEY，默认为 Claude 官方 API，只推荐 Claude 3.5 Sonnet 模型，不推荐其他模型
+# Claude API KEY，默认为 Claude 官方 API
 CLAUDE_API_KEY=your_claude_api_key
+
+# Claude 模型
+# 如留空不填则使用客户端请求体中的model字段, 如果留空不填且客户端请求体中也没有model字段，则默认使用 claude-3-5-sonnet-20241022
 CLAUDE_MODEL=claude-3-5-sonnet-20241022
 
 # Claude Provider

--- a/app/clients/base_client.py
+++ b/app/clients/base_client.py
@@ -1,45 +1,96 @@
-"""基础客户端类，定义通用接口"""
-from typing import AsyncGenerator, Any
-import aiohttp
-from app.utils.logger import logger
+"""基础客户端类,定义通用接口"""
+
+from typing import AsyncGenerator, Optional
 from abc import ABC, abstractmethod
+import aiohttp
+from aiohttp.client_exceptions import ClientError, ServerTimeoutError
+from app.utils.logger import logger
 
 
 class BaseClient(ABC):
-    def __init__(self, api_key: str, api_url: str):
+    """基础客户端类"""
+
+    # 默认超时设置(秒)
+    # total: 总超时时间
+    # connect: 连接超时时间
+    # sock_read: 读取超时时间
+        # TODO: 默认时间的设置涉及到模型推理速度，需要根据实际情况进行调整
+    DEFAULT_TIMEOUT = aiohttp.ClientTimeout(
+        total=600, connect=10, sock_read=500
+    )
+    
+
+    def __init__(
+        self,
+        api_key: str,
+        api_url: str,
+        timeout: Optional[aiohttp.ClientTimeout] = None,
+    ):
         """初始化基础客户端
-        
+
         Args:
             api_key: API密钥
             api_url: API地址
+            timeout: 请求超时设置,None则使用默认值
         """
         self.api_key = api_key
         self.api_url = api_url
-        
-    async def _make_request(self, headers: dict, data: dict) -> AsyncGenerator[bytes, None]:
+        self.timeout = timeout or self.DEFAULT_TIMEOUT
+
+    async def _make_request(
+        self, headers: dict, data: dict, timeout: Optional[aiohttp.ClientTimeout] = None
+    ) -> AsyncGenerator[bytes, None]:
         """发送请求并处理响应
-        
+
         Args:
             headers: 请求头
             data: 请求数据
-            
+            timeout: 当前请求的超时设置,None则使用实例默认值
+
         Yields:
             bytes: 原始响应数据
+
+        Raises:
+            aiohttp.ClientError: 客户端错误
+            ServerTimeoutError: 服务器超时
+            Exception: 其他异常
         """
+        request_timeout = timeout or self.timeout
+
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(self.api_url, headers=headers, json=data) as response:
-                    if response.status != 200:
+            # 使用 connector 参数来优化连接池
+            connector = aiohttp.TCPConnector(limit=100, force_close=True)
+            async with aiohttp.ClientSession(connector=connector) as session:
+                async with session.post(
+                    self.api_url, headers=headers, json=data, timeout=request_timeout
+                ) as response:
+                    # 检查响应状态
+                    if not response.ok:
                         error_text = await response.text()
-                        logger.error(f"API 请求失败: {error_text}")
-                        return
-                        
+                        error_msg = f"API 请求失败: 状态码 {response.status}, 错误信息: {error_text}"
+                        logger.error(error_msg)
+                        raise ClientError(error_msg)
+
+                    # 流式读取响应内容
                     async for chunk in response.content.iter_any():
-                        yield chunk
-                        
+                        if chunk:  # 过滤空chunks
+                            yield chunk
+
+        except ServerTimeoutError as e:
+            error_msg = f"请求超时: {str(e)}"
+            logger.error(error_msg)
+            raise
+
+        except ClientError as e:
+            error_msg = f"客户端错误: {str(e)}"
+            logger.error(error_msg)
+            raise
+
         except Exception as e:
-            logger.error(f"请求 API 时发生错误: {e}")
-            
+            error_msg = f"请求处理异常: {str(e)}"
+            logger.error(error_msg)
+            raise
+
     @abstractmethod
     async def stream_chat(self, messages: list, model: str) -> AsyncGenerator[tuple[str, str], None]:
         """流式对话，由子类实现

--- a/app/clients/base_client.py
+++ b/app/clients/base_client.py
@@ -1,9 +1,11 @@
 """基础客户端类,定义通用接口"""
 
-from typing import AsyncGenerator, Optional
 from abc import ABC, abstractmethod
+from typing import AsyncGenerator, Optional
+
 import aiohttp
 from aiohttp.client_exceptions import ClientError, ServerTimeoutError
+
 from app.utils.logger import logger
 
 
@@ -14,11 +16,8 @@ class BaseClient(ABC):
     # total: 总超时时间
     # connect: 连接超时时间
     # sock_read: 读取超时时间
-        # TODO: 默认时间的设置涉及到模型推理速度，需要根据实际情况进行调整
-    DEFAULT_TIMEOUT = aiohttp.ClientTimeout(
-        total=600, connect=10, sock_read=500
-    )
-    
+    # TODO: 默认时间的设置涉及到模型推理速度，需要根据实际情况进行调整
+    DEFAULT_TIMEOUT = aiohttp.ClientTimeout(total=600, connect=10, sock_read=500)
 
     def __init__(
         self,
@@ -92,13 +91,15 @@ class BaseClient(ABC):
             raise
 
     @abstractmethod
-    async def stream_chat(self, messages: list, model: str) -> AsyncGenerator[tuple[str, str], None]:
+    async def stream_chat(
+        self, messages: list, model: str
+    ) -> AsyncGenerator[tuple[str, str], None]:
         """流式对话，由子类实现
-        
+
         Args:
             messages: 消息列表
             model: 模型名称
-            
+
         Yields:
             tuple[str, str]: (内容类型, 内容)
         """

--- a/app/clients/claude_client.py
+++ b/app/clients/claude_client.py
@@ -1,14 +1,22 @@
 """Claude API 客户端"""
+
 import json
 from typing import AsyncGenerator
+
 from app.utils.logger import logger
+
 from .base_client import BaseClient
 
 
 class ClaudeClient(BaseClient):
-    def __init__(self, api_key: str, api_url: str = "https://api.anthropic.com/v1/messages", provider: str = "anthropic"):
+    def __init__(
+        self,
+        api_key: str,
+        api_url: str = "https://api.anthropic.com/v1/messages",
+        provider: str = "anthropic",
+    ):
         """初始化 Claude 客户端
-        
+
         Args:
             api_key: Claude API密钥
             api_url: Claude API地址
@@ -22,16 +30,16 @@ class ClaudeClient(BaseClient):
         messages: list,
         model_arg: tuple[float, float, float, float],
         model: str,
-        stream: bool = True
+        stream: bool = True,
     ) -> AsyncGenerator[tuple[str, str], None]:
         """流式或非流式对话
-        
+
         Args:
             messages: 消息列表
             model_arg: 模型参数元组[temperature, top_p, presence_penalty, frequency_penalty]
             model: 模型名称。如果是 OpenRouter, 会自动转换为 'anthropic/claude-3.5-sonnet' 格式
             stream: 是否使用流式输出，默认为 True
-            
+
         Yields:
             tuple[str, str]: (内容类型, 内容)
                 内容类型: "answer"
@@ -41,37 +49,41 @@ class ClaudeClient(BaseClient):
         if self.provider == "openrouter":
             # 转换模型名称为 OpenRouter 格式
             model = "anthropic/claude-3.5-sonnet"
-                
+
             headers = {
                 "Authorization": f"Bearer {self.api_key}",
                 "Content-Type": "application/json",
                 "HTTP-Referer": "https://github.com/ErlichLiu/DeepClaude",  # OpenRouter 需要
-                "X-Title": "DeepClaude"  # OpenRouter 需要
+                "X-Title": "DeepClaude",  # OpenRouter 需要
             }
 
             data = {
                 "model": model,  # OpenRouter 使用 anthropic/claude-3.5-sonnet 格式
                 "messages": messages,
                 "stream": stream,
-                "temperature": 1 if model_arg[0] < 0 or model_arg[0] > 1 else model_arg[0],
+                "temperature": 1
+                if model_arg[0] < 0 or model_arg[0] > 1
+                else model_arg[0],
                 "top_p": model_arg[1],
                 "presence_penalty": model_arg[2],
-                "frequency_penalty": model_arg[3]
+                "frequency_penalty": model_arg[3],
             }
         elif self.provider == "oneapi":
             headers = {
                 "Authorization": f"Bearer {self.api_key}",
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
             }
 
             data = {
                 "model": model,
                 "messages": messages,
                 "stream": stream,
-                "temperature": 1 if model_arg[0] < 0 or model_arg[0] > 1 else model_arg[0],
+                "temperature": 1
+                if model_arg[0] < 0 or model_arg[0] > 1
+                else model_arg[0],
                 "top_p": model_arg[1],
                 "presence_penalty": model_arg[2],
-                "frequency_penalty": model_arg[3]
+                "frequency_penalty": model_arg[3],
             }
         elif self.provider == "anthropic":
             headers = {
@@ -86,8 +98,10 @@ class ClaudeClient(BaseClient):
                 "messages": messages,
                 "max_tokens": 8192,
                 "stream": stream,
-                "temperature": 1 if model_arg[0] < 0 or model_arg[0] > 1 else model_arg[0], # Claude仅支持temperature与top_p
-                "top_p": model_arg[1]
+                "temperature": 1
+                if model_arg[0] < 0 or model_arg[0] > 1
+                else model_arg[0],  # Claude仅支持temperature与top_p
+                "top_p": model_arg[1],
             }
         else:
             raise ValueError(f"不支持的Claude Provider: {self.provider}")
@@ -96,44 +110,54 @@ class ClaudeClient(BaseClient):
 
         if stream:
             async for chunk in self._make_request(headers, data):
-                chunk_str = chunk.decode('utf-8')
+                chunk_str = chunk.decode("utf-8")
                 if not chunk_str.strip():
                     continue
-                    
-                for line in chunk_str.split('\n'):
-                    if line.startswith('data: '):
+
+                for line in chunk_str.split("\n"):
+                    if line.startswith("data: "):
                         json_str = line[6:]  # 去掉 'data: ' 前缀
-                        if json_str.strip() == '[DONE]':
+                        if json_str.strip() == "[DONE]":
                             return
-                            
+
                         try:
                             data = json.loads(json_str)
                             if self.provider in ("openrouter", "oneapi"):
                                 # OpenRouter/OneApi 格式
-                                content = data.get('choices', [{}])[0].get('delta', {}).get('content', '')
+                                content = (
+                                    data.get("choices", [{}])[0]
+                                    .get("delta", {})
+                                    .get("content", "")
+                                )
                                 if content:
                                     yield "answer", content
                             elif self.provider == "anthropic":
                                 # Anthropic 格式
-                                if data.get('type') == 'content_block_delta':
-                                    content = data.get('delta', {}).get('text', '')
+                                if data.get("type") == "content_block_delta":
+                                    content = data.get("delta", {}).get("text", "")
                                     if content:
                                         yield "answer", content
                             else:
-                                raise ValueError(f"不支持的Claude Provider: {self.provider}")
+                                raise ValueError(
+                                    f"不支持的Claude Provider: {self.provider}"
+                                )
                         except json.JSONDecodeError:
                             continue
         else:
             # 非流式输出
             async for chunk in self._make_request(headers, data):
                 try:
-                    response = json.loads(chunk.decode('utf-8'))
+                    response = json.loads(chunk.decode("utf-8"))
                     if self.provider in ("openrouter", "oneapi"):
-                        content = response.get('choices', [{}])[0].get('message', {}).get('content', '')
+                        content = (
+                            response.get("choices", [{}])[0]
+                            .get("message", {})
+                            .get("content", "")
+                        )
                         if content:
                             yield "answer", content
                     elif self.provider == "anthropic":
-                        content = response.get('content', [{}])[0].get('text', '')
+                        content = response.get("content", [{}])[0].get("text", "")
                         if content:
                             yield "answer", content
                     else:

--- a/app/clients/deepseek_client.py
+++ b/app/clients/deepseek_client.py
@@ -6,7 +6,7 @@ from .base_client import BaseClient
 
 
 class DeepSeekClient(BaseClient):
-    def __init__(self, api_key: str, api_url: str = "https://api.siliconflow.cn/v1/chat/completions", provider: str = "deepseek"):
+    def __init__(self, api_key: str, api_url: str = "https://api.siliconflow.cn/v1/chat/completions"):
         """初始化 DeepSeek 客户端
         
         Args:
@@ -14,7 +14,6 @@ class DeepSeekClient(BaseClient):
             api_url: DeepSeek API地址
         """
         super().__init__(api_key, api_url)
-        self.provider = provider
         
     def _process_think_tag_content(self, content: str) -> tuple[bool, str]:
         """处理包含 think 标签的内容

--- a/app/clients/deepseek_client.py
+++ b/app/clients/deepseek_client.py
@@ -1,34 +1,41 @@
 """DeepSeek API 客户端"""
+
 import json
 from typing import AsyncGenerator
+
 from app.utils.logger import logger
+
 from .base_client import BaseClient
 
 
 class DeepSeekClient(BaseClient):
-    def __init__(self, api_key: str, api_url: str = "https://api.siliconflow.cn/v1/chat/completions"):
+    def __init__(
+        self,
+        api_key: str,
+        api_url: str = "https://api.siliconflow.cn/v1/chat/completions",
+    ):
         """初始化 DeepSeek 客户端
-        
+
         Args:
             api_key: DeepSeek API密钥
             api_url: DeepSeek API地址
         """
         super().__init__(api_key, api_url)
-        
+
     def _process_think_tag_content(self, content: str) -> tuple[bool, str]:
         """处理包含 think 标签的内容
-        
+
         Args:
             content: 需要处理的内容字符串
-            
+
         Returns:
-            tuple[bool, str]: 
+            tuple[bool, str]:
                 bool: 是否检测到完整的 think 标签对
                 str: 处理后的内容
         """
         has_start = "<think>" in content
         has_end = "</think>" in content
-        
+
         if has_start and has_end:
             return True, content
         elif has_start:
@@ -37,14 +44,19 @@ class DeepSeekClient(BaseClient):
             return False, content
         else:
             return True, content
-            
-    async def stream_chat(self, messages: list, model: str = "deepseek-ai/DeepSeek-R1", is_origin_reasoning: bool = True) -> AsyncGenerator[tuple[str, str], None]:
+
+    async def stream_chat(
+        self,
+        messages: list,
+        model: str = "deepseek-ai/DeepSeek-R1",
+        is_origin_reasoning: bool = True,
+    ) -> AsyncGenerator[tuple[str, str], None]:
         """流式对话
-        
+
         Args:
             messages: 消息列表
             model: 模型名称
-            
+
         Yields:
             tuple[str, str]: (内容类型, 内容)
                 内容类型: "reasoning" 或 "content"
@@ -60,37 +72,45 @@ class DeepSeekClient(BaseClient):
             "messages": messages,
             "stream": True,
         }
-        
+
         logger.debug(f"开始流式对话：{data}")
 
         accumulated_content = ""
         is_collecting_think = False
-        
+
         async for chunk in self._make_request(headers, data):
-            chunk_str = chunk.decode('utf-8')
-            
+            chunk_str = chunk.decode("utf-8")
+
             try:
                 lines = chunk_str.splitlines()
                 for line in lines:
                     if line.startswith("data: "):
-                        json_str = line[len("data: "):]
+                        json_str = line[len("data: ") :]
                         if json_str == "[DONE]":
                             return
-                        
+
                         data = json.loads(json_str)
-                        if data and data.get("choices") and data["choices"][0].get("delta"):
+                        if (
+                            data
+                            and data.get("choices")
+                            and data["choices"][0].get("delta")
+                        ):
                             delta = data["choices"][0]["delta"]
-                            
+
                             if is_origin_reasoning:
                                 # 处理 reasoning_content
                                 if delta.get("reasoning_content"):
                                     content = delta["reasoning_content"]
                                     logger.debug(f"提取推理内容：{content}")
                                     yield "reasoning", content
-                                
-                                if delta.get("reasoning_content") is None and delta.get("content"):
+
+                                if delta.get("reasoning_content") is None and delta.get(
+                                    "content"
+                                ):
                                     content = delta["content"]
-                                    logger.info(f"提取内容信息，推理阶段结束: {content}")
+                                    logger.info(
+                                        f"提取内容信息，推理阶段结束: {content}"
+                                    )
                                     yield "content", content
                             else:
                                 # 处理其他模型的输出
@@ -100,10 +120,14 @@ class DeepSeekClient(BaseClient):
                                         continue
                                     logger.debug(f"非原生推理内容：{content}")
                                     accumulated_content += content
-                                    
+
                                     # 检查累积的内容是否包含完整的 think 标签对
-                                    is_complete, processed_content = self._process_think_tag_content(accumulated_content)
-                                    
+                                    is_complete, processed_content = (
+                                        self._process_think_tag_content(
+                                            accumulated_content
+                                        )
+                                    )
+
                                     if "<think>" in content and not is_collecting_think:
                                         # 开始收集推理内容
                                         logger.debug(f"开始收集推理内容：{content}")
@@ -125,7 +149,7 @@ class DeepSeekClient(BaseClient):
                                     else:
                                         # 普通内容
                                         yield "content", content
-                                        
+
             except json.JSONDecodeError as e:
                 logger.error(f"JSON 解析错误: {e}")
             except Exception as e:

--- a/app/deepclaude/deepclaude.py
+++ b/app/deepclaude/deepclaude.py
@@ -70,9 +70,11 @@ class DeepClaude:
         reasoning_content = []
 
         async def process_deepseek():
-            logger.info(f"开始处理 DeepSeek 流，使用模型：{deepseek_model}, 提供商: {self.deepseek_client.provider}")
+            logger.info(f"开始处理 DeepSeek 流，使用模型：{deepseek_model}")
             try:
-                async for content_type, content in self.deepseek_client.stream_chat(messages, deepseek_model, self.is_origin_reasoning):
+                async for content_type, content in self.deepseek_client.stream_chat(
+                    messages, deepseek_model, self.is_origin_reasoning
+                ):
                     if content_type == "reasoning":
                         reasoning_content.append(content)
                         response = {
@@ -146,11 +148,11 @@ class DeepClaude:
             # 用 None 标记 Claude 任务结束
             logger.info("Claude 任务处理完成，标记结束")
             await output_queue.put(None)
-        
+
         # 创建并发任务
         deepseek_task = asyncio.create_task(process_deepseek())
         claude_task = asyncio.create_task(process_claude())
-        
+
         # 等待两个任务完成，通过计数判断
         finished_tasks = 0
         while finished_tasks < 2:
@@ -159,6 +161,6 @@ class DeepClaude:
                 finished_tasks += 1
             else:
                 yield item
-        
+
         # 发送结束标记
         yield b'data: [DONE]\n\n'

--- a/app/deepclaude/deepclaude.py
+++ b/app/deepclaude/deepclaude.py
@@ -1,29 +1,38 @@
 """DeepClaude 服务，用于协调 DeepSeek 和 Claude API 的调用"""
+
+import asyncio
 import json
 import time
-import tiktoken
-import asyncio
 from typing import AsyncGenerator
+
+import tiktoken
+
+from app.clients import ClaudeClient, DeepSeekClient
 from app.utils.logger import logger
-from app.clients import DeepSeekClient, ClaudeClient
 
 
 class DeepClaude:
     """处理 DeepSeek 和 Claude API 的流式输出衔接"""
 
-    def __init__(self, deepseek_api_key: str, claude_api_key: str, 
-                 deepseek_api_url: str = "https://api.deepseek.com/v1/chat/completions", 
-                 claude_api_url: str = "https://api.anthropic.com/v1/messages",
-                 claude_provider: str = "anthropic",
-                 is_origin_reasoning: bool = True):
+    def __init__(
+        self,
+        deepseek_api_key: str,
+        claude_api_key: str,
+        deepseek_api_url: str = "https://api.deepseek.com/v1/chat/completions",
+        claude_api_url: str = "https://api.anthropic.com/v1/messages",
+        claude_provider: str = "anthropic",
+        is_origin_reasoning: bool = True,
+    ):
         """初始化 API 客户端
-        
+
         Args:
             deepseek_api_key: DeepSeek API密钥
             claude_api_key: Claude API密钥
         """
         self.deepseek_client = DeepSeekClient(deepseek_api_key, deepseek_api_url)
-        self.claude_client = ClaudeClient(claude_api_key, claude_api_url, claude_provider)
+        self.claude_client = ClaudeClient(
+            claude_api_key, claude_api_url, claude_provider
+        )
         self.is_origin_reasoning = is_origin_reasoning
 
     async def chat_completions_with_stream(
@@ -31,16 +40,16 @@ class DeepClaude:
         messages: list,
         model_arg: tuple[float, float, float, float],
         deepseek_model: str = "deepseek-reasoner",
-        claude_model: str = "claude-3-5-sonnet-20241022"
+        claude_model: str = "claude-3-5-sonnet-20241022",
     ) -> AsyncGenerator[bytes, None]:
         """处理完整的流式输出过程
-        
+
         Args:
             messages: 初始消息列表
             model_arg: 模型参数
             deepseek_model: DeepSeek 模型名称
             claude_model: Claude 模型名称
-            
+
         Yields:
             字节流数据，格式如下：
             {
@@ -83,19 +92,25 @@ class DeepClaude:
                             "object": "chat.completion.chunk",
                             "created": created_time,
                             "model": deepseek_model,
-                            "choices": [{
-                                "index": 0,
-                                "delta": {
-                                    "role": "assistant",
-                                    "reasoning_content": content,
-                                    "content": ""
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "delta": {
+                                        "role": "assistant",
+                                        "reasoning_content": content,
+                                        "content": "",
+                                    },
                                 }
-                            }]
+                            ],
                         }
-                        await output_queue.put(f"data: {json.dumps(response)}\n\n".encode('utf-8'))
+                        await output_queue.put(
+                            f"data: {json.dumps(response)}\n\n".encode("utf-8")
+                        )
                     elif content_type == "content":
                         # 当收到 content 类型时，将完整的推理内容发送到 claude_queue，并结束 DeepSeek 流处理
-                        logger.info(f"DeepSeek 推理完成，收集到的推理内容长度：{len(''.join(reasoning_content))}")
+                        logger.info(
+                            f"DeepSeek 推理完成，收集到的推理内容长度：{len(''.join(reasoning_content))}"
+                        )
                         await claude_queue.put("".join(reasoning_content))
                         break
             except Exception as e:
@@ -109,7 +124,9 @@ class DeepClaude:
             try:
                 logger.info("等待获取 DeepSeek 的推理内容...")
                 reasoning = await claude_queue.get()
-                logger.debug(f"获取到推理内容，内容长度：{len(reasoning) if reasoning else 0}")
+                logger.debug(
+                    f"获取到推理内容，内容长度：{len(reasoning) if reasoning else 0}"
+                )
                 if not reasoning:
                     logger.warning("未能获取到有效的推理内容，将使用默认提示继续")
                     reasoning = "获取推理内容失败"
@@ -118,7 +135,7 @@ class DeepClaude:
                 combined_content = f"""
                 Here's my another model's reasoning process:\n{reasoning}\n\n
                 Based on this reasoning, provide your response directly to me:"""
-                
+
                 # 改造最后一个消息对象，判断消息对象是 role = user，然后在这个对象的 content 后追加新的 String
                 last_message = claude_messages[-1]
                 if last_message.get("role", "") == "user":
@@ -126,9 +143,15 @@ class DeepClaude:
                     fixed_content = f"Here's my original input:\n{original_content}\n\n{combined_content}"
                     last_message["content"] = fixed_content
                 # 处理可能 messages 内存在 role = system 的情况，如果有，则去掉当前这一条的消息对象
-                claude_messages = [message for message in claude_messages if message.get("role", "") != "system"]
+                claude_messages = [
+                    message
+                    for message in claude_messages
+                    if message.get("role", "") != "system"
+                ]
 
-                logger.info(f"开始处理 Claude 流，使用模型: {claude_model}, 提供商: {self.claude_client.provider}")
+                logger.info(
+                    f"开始处理 Claude 流，使用模型: {claude_model}, 提供商: {self.claude_client.provider}"
+                )
 
                 async for content_type, content in self.claude_client.stream_chat(
                     messages=claude_messages,
@@ -141,15 +164,16 @@ class DeepClaude:
                             "object": "chat.completion.chunk",
                             "created": created_time,
                             "model": claude_model,
-                            "choices": [{
-                                "index": 0,
-                                "delta": {
-                                    "role": "assistant",
-                                    "content": content
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "delta": {"role": "assistant", "content": content},
                                 }
-                            }]
+                            ],
                         }
-                        await output_queue.put(f"data: {json.dumps(response)}\n\n".encode('utf-8'))
+                        await output_queue.put(
+                            f"data: {json.dumps(response)}\n\n".encode("utf-8")
+                        )
             except Exception as e:
                 logger.error(f"处理 Claude 流时发生错误: {e}")
             # 用 None 标记 Claude 任务结束
@@ -157,8 +181,8 @@ class DeepClaude:
             await output_queue.put(None)
 
         # 创建并发任务
-        deepseek_task = asyncio.create_task(process_deepseek())
-        claude_task = asyncio.create_task(process_claude())
+        asyncio.create_task(process_deepseek())
+        asyncio.create_task(process_claude())
 
         # 等待两个任务完成，通过计数判断
         finished_tasks = 0
@@ -170,23 +194,23 @@ class DeepClaude:
                 yield item
 
         # 发送结束标记
-        yield b'data: [DONE]\n\n'
+        yield b"data: [DONE]\n\n"
 
     async def chat_completions_without_stream(
         self,
         messages: list,
         model_arg: tuple[float, float, float, float],
         deepseek_model: str = "deepseek-reasoner",
-        claude_model: str = "claude-3-5-sonnet-20241022"
+        claude_model: str = "claude-3-5-sonnet-20241022",
     ) -> dict:
         """处理非流式输出过程
-        
+
         Args:
             messages: 初始消息列表
             model_arg: 模型参数
             deepseek_model: DeepSeek 模型名称
             claude_model: Claude 模型名称
-            
+
         Returns:
             dict: OpenAI 格式的完整响应
         """
@@ -196,7 +220,9 @@ class DeepClaude:
 
         # 1. 获取 DeepSeek 的推理内容（仍然使用流式）
         try:
-            async for content_type, content in self.deepseek_client.stream_chat(messages, deepseek_model, self.is_origin_reasoning):
+            async for content_type, content in self.deepseek_client.stream_chat(
+                messages, deepseek_model, self.is_origin_reasoning
+            ):
                 if content_type == "reasoning":
                     reasoning_content.append(content)
                 elif content_type == "content":
@@ -210,21 +236,29 @@ class DeepClaude:
         claude_messages = messages.copy()
 
         combined_content = f"""
-        Here's my another model's reasoning process:\n{reasoning}\n\n
-        Based on this reasoning, provide your response directly to me:"""
-        
+            Here's my another model's reasoning process:\n{reasoning}\n\n
+            Based on this reasoning, provide your response directly to me:"""
+
         # 改造最后一个消息对象，判断消息对象是 role = user，然后在这个对象的 content 后追加新的 String
         last_message = claude_messages[-1]
         if last_message.get("role", "") == "user":
             original_content = last_message["content"]
-            fixed_content = f"Here's my original input:\n{original_content}\n\n{combined_content}"
+            fixed_content = (
+                f"Here's my original input:\n{original_content}\n\n{combined_content}"
+            )
             last_message["content"] = fixed_content
 
         # 处理可能 messages 内存在 role = system 的情况
-        claude_messages = [message for message in claude_messages if message.get("role", "") != "system"]
+        claude_messages = [
+            message
+            for message in claude_messages
+            if message.get("role", "") != "system"
+        ]
 
         # 拼接所有 content 为一个字符串，计算 token
-        token_content = "\n".join([message.get("content", "") for message in claude_messages])
+        token_content = "\n".join(
+            [message.get("content", "") for message in claude_messages]
+        )
         encoding = tiktoken.encoding_for_model("gpt-4o")
         input_tokens = encoding.encode(token_content)
         logger.debug(f"输入 Tokens: {len(input_tokens)}")
@@ -233,15 +267,16 @@ class DeepClaude:
         # 3. 获取 Claude 的非流式响应
         try:
             answer = ""
+            output_tokens = []  # 初始化 output_tokens
             async for content_type, content in self.claude_client.stream_chat(
                 messages=claude_messages,
                 model_arg=model_arg,
                 model=claude_model,
-                stream=False
+                stream=False,
             ):
                 if content_type == "answer":
                     answer += content
-                output_tokens = encoding.encode(answer)
+                    output_tokens = encoding.encode(answer)  # 更新 output_tokens
                 logger.debug(f"输出 Tokens: {len(output_tokens)}")
 
             # 4. 构造 OpenAI 格式的响应
@@ -250,20 +285,22 @@ class DeepClaude:
                 "object": "chat.completion",
                 "created": created_time,
                 "model": claude_model,
-                "choices": [{
-                    "index": 0,
-                    "message": {
-                        "role": "assistant",
-                        "content": answer,
-                        "reasoning_content": reasoning
-                    },
-                    "finish_reason": "stop"
-                }],
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": answer,
+                            "reasoning_content": reasoning,
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
                 "usage": {
                     "prompt_tokens": len(input_tokens),
                     "completion_tokens": len(output_tokens),
-                    "total_tokens": len(input_tokens + output_tokens)
-                }
+                    "total_tokens": len(input_tokens + output_tokens),
+                },
             }
         except Exception as e:
             logger.error(f"获取 Claude 响应时发生错误: {e}")

--- a/app/main.py
+++ b/app/main.py
@@ -18,7 +18,7 @@ app = FastAPI(title="DeepClaude API")
 ALLOW_ORIGINS = os.getenv("ALLOW_ORIGINS", "*")
 
 CLAUDE_API_KEY = os.getenv("CLAUDE_API_KEY")
-CLAUDE_MODEL = os.getenv("CLAUDE_MODEL")
+ENV_CLAUDE_MODEL = os.getenv("CLAUDE_MODEL")
 CLAUDE_PROVIDER = os.getenv("CLAUDE_PROVIDER", "anthropic") # Claude模型提供商, 默认为anthropic
 CLAUDE_API_URL = os.getenv("CLAUDE_API_URL", "https://api.anthropic.com/v1/messages")
 
@@ -81,6 +81,10 @@ async def chat_completions(request: Request):
         body = await request.json()
         messages = body.get("messages")
 
+        # 获取模型id, 判断是否使用请求体中的模型id, 否则使用环境变量中的模型id
+        body_claude_model = body.get("model", "claude-3-5-sonnet-20241022")
+        claude_model = ENV_CLAUDE_MODEL if ENV_CLAUDE_MODEL != "" else body_claude_model
+
         # 2. 获取并验证参数
         model_arg = (
             get_and_validate_params(body)
@@ -92,7 +96,7 @@ async def chat_completions(request: Request):
                 messages=messages,
                 model_arg=model_arg,
                 deepseek_model=DEEPSEEK_MODEL,
-                claude_model=CLAUDE_MODEL
+                claude_model=claude_model
             ),
             media_type="text/event-stream"
         )

--- a/app/main.py
+++ b/app/main.py
@@ -1,16 +1,17 @@
 import os
 import sys
+
 from dotenv import load_dotenv
+from fastapi import Depends, FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
+
+from app.deepclaude.deepclaude import DeepClaude
+from app.utils.auth import verify_api_key
+from app.utils.logger import logger
 
 # 加载环境变量
 load_dotenv()
-
-from fastapi import FastAPI, Depends, Request
-from fastapi.responses import StreamingResponse
-from fastapi.middleware.cors import CORSMiddleware
-from app.utils.logger import logger
-from app.utils.auth import verify_api_key
-from app.deepclaude.deepclaude import DeepClaude
 
 app = FastAPI(title="DeepClaude API")
 
@@ -19,17 +20,23 @@ ALLOW_ORIGINS = os.getenv("ALLOW_ORIGINS", "*")
 
 CLAUDE_API_KEY = os.getenv("CLAUDE_API_KEY")
 ENV_CLAUDE_MODEL = os.getenv("CLAUDE_MODEL")
-CLAUDE_PROVIDER = os.getenv("CLAUDE_PROVIDER", "anthropic") # Claude模型提供商, 默认为anthropic
+CLAUDE_PROVIDER = os.getenv(
+    "CLAUDE_PROVIDER", "anthropic"
+)  # Claude模型提供商, 默认为anthropic
 CLAUDE_API_URL = os.getenv("CLAUDE_API_URL", "https://api.anthropic.com/v1/messages")
 
 DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY")
-DEEPSEEK_API_URL = os.getenv("DEEPSEEK_API_URL")
-DEEPSEEK_MODEL = os.getenv("DEEPSEEK_MODEL")
+DEEPSEEK_API_URL = os.getenv(
+    "DEEPSEEK_API_URL", "https://api.deepseek.com/v1/chat/completions"
+)
+DEEPSEEK_MODEL = os.getenv("DEEPSEEK_MODEL", "deepseek-reasoner")
 
 IS_ORIGIN_REASONING = os.getenv("IS_ORIGIN_REASONING", "True").lower() == "true"
 
 # CORS设置
-allow_origins_list = ALLOW_ORIGINS.split(",") if ALLOW_ORIGINS else [] # 将逗号分隔的字符串转换为列表
+allow_origins_list = (
+    ALLOW_ORIGINS.split(",") if ALLOW_ORIGINS else []
+)  # 将逗号分隔的字符串转换为列表
 
 app.add_middleware(
     CORSMiddleware,
@@ -50,17 +57,19 @@ deep_claude = DeepClaude(
     DEEPSEEK_API_URL,
     CLAUDE_API_URL,
     CLAUDE_PROVIDER,
-    IS_ORIGIN_REASONING
+    IS_ORIGIN_REASONING,
 )
 
 # 验证日志级别
 logger.debug("当前日志级别为 DEBUG")
 logger.info("开始请求")
 
+
 @app.get("/", dependencies=[Depends(verify_api_key)])
 async def root():
     logger.info("访问了根路径")
     return {"message": "Welcome to DeepClaude API"}
+
 
 @app.get("/v1/models")
 async def list_models():
@@ -68,35 +77,40 @@ async def list_models():
     获取可用模型列表
     返回格式遵循 OpenAI API 标准
     """
-    models = [{
-        "id": "deepclaude",
-        "object": "model",
-        "created": 1677610602,
-        "owned_by": "deepclaude",
-        "permission": [{
-            "id": "modelperm-deepclaude",
-            "object": "model_permission",
+    models = [
+        {
+            "id": "deepclaude",
+            "object": "model",
             "created": 1677610602,
-            "allow_create_engine": False,
-            "allow_sampling": True,
-            "allow_logprobs": True,
-            "allow_search_indices": False,
-            "allow_view": True,
-            "allow_fine_tuning": False,
-            "organization": "*",
-            "group": None,
-            "is_blocking": False
-        }],
-        "root": "deepclaude",
-        "parent": None
-    }]
-    
+            "owned_by": "deepclaude",
+            "permission": [
+                {
+                    "id": "modelperm-deepclaude",
+                    "object": "model_permission",
+                    "created": 1677610602,
+                    "allow_create_engine": False,
+                    "allow_sampling": True,
+                    "allow_logprobs": True,
+                    "allow_search_indices": False,
+                    "allow_view": True,
+                    "allow_fine_tuning": False,
+                    "organization": "*",
+                    "group": None,
+                    "is_blocking": False,
+                }
+            ],
+            "root": "deepclaude",
+            "parent": None,
+        }
+    ]
+
     return {"object": "list", "data": models}
+
 
 @app.post("/v1/chat/completions", dependencies=[Depends(verify_api_key)])
 async def chat_completions(request: Request):
     """处理聊天完成请求，支持流式和非流式输出
-    
+
     请求体格式应与 OpenAI API 保持一致，包含：
     - messages: 消息列表
     - model: 模型名称（可选）
@@ -117,9 +131,7 @@ async def chat_completions(request: Request):
         claude_model = ENV_CLAUDE_MODEL if ENV_CLAUDE_MODEL != "" else body_claude_model
 
         # 2. 获取并验证参数
-        model_arg = (
-            get_and_validate_params(body)
-        )
+        model_arg = get_and_validate_params(body)
         stream = model_arg[4]  # 获取 stream 参数
 
         # 3. 根据 stream 参数返回相应的响应
@@ -129,9 +141,11 @@ async def chat_completions(request: Request):
                     messages=messages,
                     model_arg=model_arg[:4],  # 不传递 stream 参数
                     deepseek_model=DEEPSEEK_MODEL,
-                    claude_model=cluade_model
+                    claude_model=claude_model
+                    if claude_model
+                    else "claude-3-5-sonnet-20241022",
                 ),
-                media_type="text/event-stream"
+                media_type="text/event-stream",
             )
         else:
             # 非流式输出
@@ -140,6 +154,8 @@ async def chat_completions(request: Request):
                 model_arg=model_arg[:4],  # 不传递 stream 参数
                 deepseek_model=DEEPSEEK_MODEL,
                 claude_model=claude_model
+                if claude_model
+                else "claude-3-5-sonnet-20241022",
             )
             return response
 
@@ -157,8 +173,14 @@ def get_and_validate_params(body):
     frequency_penalty: float = body.get("frequency_penalty", 0.0)
     stream: bool = body.get("stream", True)
 
-    if "sonnet" in body.get("model", ""): # Only Sonnet 设定 temperature 必须在 0 到 1 之间
-        if not isinstance(temperature, (float)) or temperature < 0.0 or temperature > 1.0:
+    if "sonnet" in body.get(
+        "model", ""
+    ):  # Only Sonnet 设定 temperature 必须在 0 到 1 之间
+        if (
+            not isinstance(temperature, (float))
+            or temperature < 0.0
+            or temperature > 1.0
+        ):
             raise ValueError("Sonnet 设定 temperature 必须在 0 到 1 之间")
 
     return (temperature, top_p, presence_penalty, frequency_penalty, stream)


### PR DESCRIPTION
## 主要更改
Claude侧模型支持使用客户端请求体中定义的model #23 

## 更改说明

### 1. `main.py`
读取请求体中的`model`字段, 如果为空则默认赋值为`claude-3-5-sonnet`. 判断环境变量`ENV_CLAUDE_MODEL`是否为空字符串, 若是, 则使用请求体中的model作为claude model进行请求.

优先级:
```txt
环境变量 -> 请求体model字段 -> 默认值"claude-3-5-sonnet"
```

### 2. `.env.example`
增加`CLAUDE_MODEL`变量说明.