### PR TITLE
Add proxy configuration support in .env.example and base_client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,10 @@ OPENAI_COMPOSITE_API_KEY=your_api_key
 OPENAI_COMPOSITE_API_URL=https://generativelanguage.googleapis.com/v1beta/openai/chat/completions
 OPENAI_COMPOSITE_MODEL=gemini-2.0-pro-exp
 
+# 代理配置
+USE_PROXY=false # 是否使用代理,默认不使用.如使用请改为true,并修改PROXY_URL为对应代理地址
+PROXY_URL=http://127.0.0.1:7890 # 代理服务器地址，如不填写则不使用代理.此处默认为Clash,如果使用其他代理,需改为对应的代理地址
+
 # 日志配置
 # 可选值：DEBUG, INFO, WARNING, ERROR, CRITICAL
 LOG_LEVEL=INFO

--- a/app/clients/base_client.py
+++ b/app/clients/base_client.py
@@ -70,10 +70,7 @@ class BaseClient(ABC):
             
             async with aiohttp.ClientSession(connector=connector) as session:
                 async with session.post(
-                    self.api_url,
-                    headers=headers,
-                    json=data,
-                    timeout=request_timeout,
+                    self.api_url, headers=headers, json=data, timeout=request_timeout,
                     proxy=proxy
                 ) as response:
                     # 检查响应状态

--- a/app/clients/base_client.py
+++ b/app/clients/base_client.py
@@ -62,7 +62,7 @@ class BaseClient(ABC):
         request_timeout = timeout or self.timeout
 
         try:
-            # 配置连接器和代理
+            # 使用 connector 参数来优化连接池
             connector = aiohttp.TCPConnector(limit=100, force_close=True)
             
             # 根据环境变量决定是否使用代理


### PR DESCRIPTION
本地部署完成后，调用api请求deepgemini模型报以下错误：

![](https://daytime001-picturebed.oss-cn-nanjing.aliyuncs.com/typora/bug.jpg)

经排查后发现问题出在代理上，在调用gemini时对网络有要求，因此设置了两个代理相关的环境变量`USE_PROXY`和`PROXY_URL`,并在`base_client`文件中进行了相应修改。

修改完成后可供用户自主选择是否使用代理，如Gemini等模型则必须使用，其它选择直连即可