### PR TITLE
Feat/allow proxy by model

### DIFF
--- a/app/deepclaude/deepclaude.py
+++ b/app/deepclaude/deepclaude.py
@@ -22,7 +22,8 @@ class DeepClaude:
         claude_api_url: str = "https://api.anthropic.com/v1/messages",
         claude_provider: str = "anthropic",
         is_origin_reasoning: bool = True,
-        proxy: str = None,
+        reasoner_proxy: str = None,
+        target_proxy: str = None
     ):
         """初始化 API 客户端
 
@@ -33,11 +34,12 @@ class DeepClaude:
             claude_api_url: Claude API地址
             claude_provider: Claude 提供商
             is_origin_reasoning: 是否使用原始推理
-            proxy: 代理服务器地址
+            reasoner_proxy: reasoner模型代理服务器地址
+            target_proxy: target模型代理服务器地址
         """
-        self.deepseek_client = DeepSeekClient(deepseek_api_key, deepseek_api_url, proxy=proxy)
+        self.deepseek_client = DeepSeekClient(deepseek_api_key, deepseek_api_url, proxy=reasoner_proxy)
         self.claude_client = ClaudeClient(
-            claude_api_key, claude_api_url, claude_provider, proxy=proxy
+            claude_api_key, claude_api_url, claude_provider, proxy=target_proxy
         )
         self.is_origin_reasoning = is_origin_reasoning
 

--- a/app/manager/model_manager.py
+++ b/app/manager/model_manager.py
@@ -126,6 +126,9 @@ class ModelManager:
             proxy = proxy_config.get("proxy_address")
             logger.info(f"模型 {model_name} 将使用代理: {proxy}")
         
+        # 默认设置为True, 和默认行为保持一致（只要全局开始proxy_open, 则模型默认开启proxy_open）
+        reasoner_proxy = proxy if reasoner_config.get('proxy_open', True) else None
+        target_proxy = proxy if target_config.get('proxy_open', True) else None
         # 创建模型实例
         if target_config.get("model_format", "") == "anthropic":
             # 创建 DeepClaude 实例
@@ -136,7 +139,8 @@ class ModelManager:
                 claude_api_url=f"{target_config['api_base_url']}/{target_config['api_request_address']}",
                 claude_provider="anthropic",
                 is_origin_reasoning=reasoner_config.get("is_origin_reasoning", self.is_origin_reasoning),
-                proxy=proxy,
+                reasoner_proxy=reasoner_proxy,
+                target_proxy=target_proxy,
             )
         else:
             # 创建 OpenAICompatibleComposite 实例
@@ -146,7 +150,8 @@ class ModelManager:
                 deepseek_api_url=f"{reasoner_config['api_base_url']}/{reasoner_config['api_request_address']}",
                 openai_api_url=f"{target_config['api_base_url']}/{target_config['api_request_address']}",
                 is_origin_reasoning=reasoner_config.get("is_origin_reasoning", self.is_origin_reasoning),
-                proxy=proxy,
+                reasoner_proxy=reasoner_proxy,
+                target_proxy=target_proxy,
             )
         
         # 缓存实例

--- a/app/model_manager/model_configs.json
+++ b/app/model_manager/model_configs.json
@@ -6,7 +6,8 @@
             "api_base_url": "https://api.deepseek.com",
             "api_request_address": "v1/chat/completions",
             "is_origin_reasoning": true,
-            "is_valid": false
+            "is_valid": false,
+            "proxy_open": false
         },
         "Volcengine/DeepSeek-R1": {
             "model_id": "deepseek-r1-250120",
@@ -14,7 +15,8 @@
             "api_base_url": "https://ark.cn-beijing.volces.com/api",
             "api_request_address": "v3/chat/completions",
             "is_origin_reasoning": true,
-            "is_valid": true
+            "is_valid": true,
+            "proxy_open": false
         }
     },
     "target_models": {
@@ -24,7 +26,8 @@
             "api_base_url": "https://api.anthropic.com",
             "api_request_address": "v1/messages",
             "model_format": "anthropic",
-            "is_valid": false
+            "is_valid": false,
+            "proxy_open": true
         },
         "DMXapi/Claude-3-7-Sonnet": {
             "model_id": "claude-3-7-sonnet-20250219",
@@ -32,7 +35,8 @@
             "api_base_url": "https://www.dmxapi.cn",
             "api_request_address": "v1/chat/completions",
             "model_format": "openai",
-            "is_valid": true
+            "is_valid": true,
+            "proxy_open": false
         },
         "OpenRouter/Claude-3-7-Sonnet": {
             "model_id": "anthropic/claude-3.7-sonnet",
@@ -40,7 +44,8 @@
             "api_base_url": "https://openrouter.ai/api",
             "api_request_address": "v1/chat/completions",
             "model_format": "openai",
-            "is_valid": true
+            "is_valid": true,
+            "proxy_open": false
         },
         "Gemini/Gemini-2.0-Flash": {
             "model_id": "gemini-2.0-flash",
@@ -48,7 +53,8 @@
             "api_base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
             "api_request_address": "chat/completions",
             "model_format": "openai",
-            "is_valid": true
+            "is_valid": true,
+            "proxy_open": true
         },
         "Gemini/Gemini-2.0-Pro": {
             "model_id": "gemini-2.0-pro-exp",
@@ -56,7 +62,8 @@
             "api_base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
             "api_request_address": "chat/completions",
             "model_format": "openai",
-            "is_valid": true
+            "is_valid": true,
+            "proxy_open": true
         }
     },
     "proxy": {

--- a/app/openai_composite/openai_composite.py
+++ b/app/openai_composite/openai_composite.py
@@ -20,7 +20,8 @@ class OpenAICompatibleComposite:
         deepseek_api_url: str = "https://api.deepseek.com/v1/chat/completions",
         openai_api_url: str = "",  # 将由具体实现提供
         is_origin_reasoning: bool = True,
-        proxy: str = None,
+        reasoner_proxy: str = None,
+        target_proxy: str = None
     ):
         """初始化 API 客户端
 
@@ -30,10 +31,11 @@ class OpenAICompatibleComposite:
             deepseek_api_url: DeepSeek API地址
             openai_api_url: OpenAI 兼容服务的 API地址
             is_origin_reasoning: 是否使用原始推理过程
-            proxy: 代理服务器地址
+            reasoner_proxy: reasoner模型代理服务器地址
+            target_proxy: target模型代理服务器地址
         """
-        self.deepseek_client = DeepSeekClient(deepseek_api_key, deepseek_api_url, proxy=proxy)
-        self.openai_client = OpenAICompatibleClient(openai_api_key, openai_api_url, proxy=proxy)
+        self.deepseek_client = DeepSeekClient(deepseek_api_key, deepseek_api_url, proxy=reasoner_proxy)
+        self.openai_client = OpenAICompatibleClient(openai_api_key, openai_api_url, proxy=target_proxy)
         self.is_origin_reasoning = is_origin_reasoning
 
     async def chat_completions_with_stream(

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -292,6 +292,10 @@
                             <input class="form-check-input is-valid" type="checkbox">
                             <label class="form-check-label">模型可用</label>
                         </div>
+                        <div class="mb-3 form-check form-switch">
+                            <input class="form-check-input is-proxy-open" type="checkbox">
+                            <label class="form-check-label">是否开启代理</label>
+                        </div>
                         <button type="button" class="btn btn-primary save-model-btn">保存</button>
                     </form>
                 </div>
@@ -342,6 +346,10 @@
                         <div class="mb-3 form-check form-switch">
                             <input class="form-check-input is-valid" type="checkbox">
                             <label class="form-check-label">模型可用</label>
+                        </div>
+                        <div class="mb-3 form-check form-switch">
+                            <input class="form-check-input is-proxy-open" type="checkbox">
+                            <label class="form-check-label">是否开启代理</label>
                         </div>
                         <button type="button" class="btn btn-primary save-model-btn">保存</button>
                     </form>

--- a/frontend/js/config.js
+++ b/frontend/js/config.js
@@ -182,6 +182,7 @@ function renderReasonerModel(name, config) {
     form.querySelector('.api-request-address').value = config.api_request_address || '';
     form.querySelector('.is-origin-reasoning').checked = config.is_origin_reasoning || false;
     form.querySelector('.is-valid').checked = config.is_valid || false;
+    form.querySelector('.is-proxy-open').checked = config.proxy_open || false;
     
     // 绑定保存按钮事件
     form.querySelector('.save-model-btn').addEventListener('click', () => {
@@ -225,6 +226,7 @@ function renderTargetModel(name, config) {
     form.querySelector('.api-request-address').value = config.api_request_address || '';
     form.querySelector('.model-format').value = config.model_format || 'openai';
     form.querySelector('.is-valid').checked = config.is_valid || false;
+    form.querySelector('.is-proxy-open').checked = config.proxy_open || false;
     
     // 绑定保存按钮事件
     form.querySelector('.save-model-btn').addEventListener('click', () => {


### PR DESCRIPTION
When I used the deepgeminiflash composite model, I need to config the proxy for the gemini model, but there is no need to set the proxy config for deepseek, the deepseek api should be visited directly. Currenty, I config the traffic split rules in the clash, but it's a little bit complex, so I want to split the proxy config  to make it more flexible.

the working log as following:
![image](https://github.com/user-attachments/assets/0d7d1a94-819e-4754-8a63-787b45f5450c)
